### PR TITLE
fix/determinism expiration

### DIFF
--- a/sparse_blobpool/core/events.py
+++ b/sparse_blobpool/core/events.py
@@ -46,3 +46,4 @@ class Event:
     target_id: ActorId = field(compare=False)
     payload: EventPayload = field(compare=False)
     priority: int = 0
+    sequence: int = 0

--- a/sparse_blobpool/core/simulator.py
+++ b/sparse_blobpool/core/simulator.py
@@ -36,6 +36,7 @@ class Simulator:
         self._actors: dict[ActorId, Actor] = {}
         self._rng = Random(seed)
         self._events_processed: int = 0
+        self._next_event_sequence: int = 0
 
         self._network: Network | None = None
         self._block_producer: BlockProducer | None = None
@@ -104,6 +105,8 @@ class Simulator:
             raise ValueError(
                 f"Cannot schedule event in the past: {event.timestamp} < {self._current_time}"
             )
+        event.sequence = self._next_event_sequence
+        self._next_event_sequence += 1
         heapq.heappush(self._event_queue, event)
 
     def deliver_command(self, command: Command, target_id: ActorId) -> None:


### PR DESCRIPTION
## Summary
- Make event scheduling deterministic with a stable sequence tiebreaker.
- Enforce transaction expiration in nodes using configured timeout.
- Stabilize peer iteration/selection to avoid hash-order nondeterminism.

## Testing
- uv run pytest